### PR TITLE
small fixes & minor touches (closes #67)

### DIFF
--- a/ClassevivaPCTO/Controls/AbsencesListView.xaml
+++ b/ClassevivaPCTO/Controls/AbsencesListView.xaml
@@ -37,7 +37,7 @@
                         <!-- ="{ThemeResource SystemControlBackgroundBaseMediumBrush}" -->
                     </Ellipse>
                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center"
-                               Text="{x:Bind ShortEventName}" FontSize="16" Foreground="#FFFFFF" />
+                               Text="{x:Bind ShortEventName}" FontSize="16" Foreground="#FFFFFF" FontWeight="Medium"/>
 
                 </Grid>
 

--- a/ClassevivaPCTO/Controls/AgendaListView.xaml
+++ b/ClassevivaPCTO/Controls/AgendaListView.xaml
@@ -41,9 +41,11 @@
                 <TextBlock RelativePanel.RightOf="dataEnd" x:Name="tipoEvento" TextWrapping="Wrap"
                            RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            MaxWidth="500"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Text="{x:Bind EventType}"
+                           FontStyle="Italic"
                            Style="{ThemeResource BaseTextBlockStyle}"
-                           Margin="6,8,0,0" />
+                           Margin="12,10,0,0" />
 
 
                 <TextBlock RelativePanel.RightOf="titoloEvento" RelativePanel.AlignVerticalCenterWith="titoloEvento"

--- a/ClassevivaPCTO/Controls/AgendaListView.xaml
+++ b/ClassevivaPCTO/Controls/AgendaListView.xaml
@@ -43,16 +43,16 @@
                            MaxWidth="500"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Text="{x:Bind EventType}"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BaseTextBlockStyle}"
-                           Margin="12,10,0,0" />
+                           Margin="10,10,0,0" />
 
 
                 <TextBlock RelativePanel.RightOf="titoloEvento" RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            x:Name="dataStart"
 
                            Text="{x:Bind  CurrentObject.evtDatetimeBegin, Converter={StaticResource DateTimeToHourConverter}}"
-                           FontStyle="Italic" FontWeight="Medium"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Margin="10,12,0,0" />
@@ -60,7 +60,7 @@
                 <TextBlock RelativePanel.RightOf="dataStart" RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            x:Name="placeholderData"
                            Text="-"
-                           FontStyle="Italic" FontWeight="Medium"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Margin="6,12,6,0" />
@@ -69,7 +69,7 @@
                 <TextBlock RelativePanel.RightOf="placeholderData" RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            x:Name="dataEnd"
                            Text="{x:Bind  CurrentObject.evtDatetimeEnd, Converter={StaticResource DateTimeToHourConverter}}"
-                           FontStyle="Italic" FontWeight="Medium"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Margin="0,12,0,0" />

--- a/ClassevivaPCTO/Controls/AgendaMultipleDaysListView.xaml
+++ b/ClassevivaPCTO/Controls/AgendaMultipleDaysListView.xaml
@@ -25,55 +25,61 @@
                 <!-- icon calendar -->
                 <FontIcon x:Name="IconCalendar" FontFamily="{StaticResource FluentIcons}" Glyph="&#xE787;"
                           RelativePanel.AlignVerticalCenterWithPanel="True"
-                          Margin="0,0,8,0" />
-
+                          Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                          Margin="4,0,8,0" />
 
                 <TextBlock x:Name="titoloEvento" TextWrapping="Wrap"
                            RelativePanel.RightOf="IconCalendar"
                            MaxWidth="500"
+                           IsTextSelectionEnabled="True"
                            Text="{x:Bind Title}"
-                           IsTextSelectionEnabled="True"
                            Style="{ThemeResource BaseTextBlockStyle}"
-                           Margin="6,6,0,0" />
+                           Margin="6,12,0,0" />
 
-
-                <TextBlock RelativePanel.RightOf="titoloEvento" x:Name="tipoEvento" TextWrapping="Wrap"
+                <TextBlock RelativePanel.RightOf="dataEnd" x:Name="tipoEvento" TextWrapping="Wrap"
+                           RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            MaxWidth="500"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Text="{x:Bind EventType}"
+                           FontWeight="Medium"
                            Style="{ThemeResource BaseTextBlockStyle}"
-                           Margin="6,6,0,0" />
+                           Margin="10,10,0,0" />
 
+                <TextBlock RelativePanel.RightOf="titoloEvento" RelativePanel.AlignVerticalCenterWith="titoloEvento"
+                           x:Name="dataStart"
 
-                <TextBlock RelativePanel.Below="titoloEvento" x:Name="dataStart"
-                           RelativePanel.RightOf="IconCalendar"
                            Text="{x:Bind  CurrentObject.evtDatetimeBegin, Converter={StaticResource DateTimeToHourConverter}}"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           IsTextSelectionEnabled="True"
-                           Margin="6,0,0,0" />
-
-                <TextBlock RelativePanel.RightOf="dataStart" RelativePanel.Below="titoloEvento"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Margin="12,12,0,0" />
+                <!-- trattino -->
+                <TextBlock RelativePanel.RightOf="dataStart" RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            x:Name="placeholderData"
                            Text="-"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           Margin="6,0,6,0" />
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Margin="6,12,6,0" />
 
 
-                <TextBlock RelativePanel.RightOf="placeholderData" RelativePanel.Below="titoloEvento" x:Name="dataEnd"
+                <TextBlock RelativePanel.RightOf="placeholderData" RelativePanel.AlignVerticalCenterWith="titoloEvento"
+                           x:Name="dataEnd"
                            Text="{x:Bind  CurrentObject.evtDatetimeEnd, Converter={StaticResource DateTimeToHourConverter}}"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           IsTextSelectionEnabled="True"
-                           Margin="0,0,0,0" />
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Margin="0,12,0,0" />
 
-                <TextBlock RelativePanel.Below="dataStart" x:Name="descriptionEvent"
+                <TextBlock RelativePanel.Below="titoloEvento" x:Name="descriptionEvent"
                            RelativePanel.RightOf="IconCalendar"
                            TextWrapping="Wrap"
                            Text="{x:Bind  CurrentObject.notes}"
                            Style="{ThemeResource BodyTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           FontWeight="SemiBold"
                            IsTextSelectionEnabled="True"
-                           Margin="6,6,0,6" />
+                           Margin="6,4,0,12" />
 
 
             </RelativePanel>
@@ -88,63 +94,70 @@
                 <!-- icon calendar -->
                 <FontIcon x:Name="IconCalendar" FontFamily="{StaticResource FluentIcons}" Glyph="&#xE787;"
                           RelativePanel.AlignVerticalCenterWithPanel="True"
-                          Margin="0,0,8,0" />
+                          Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                          Margin="4,0,8,0" />
 
 
                 <TextBlock x:Name="titoloEvento" TextWrapping="Wrap"
                            RelativePanel.RightOf="IconCalendar"
                            MaxWidth="500"
-                           Text="{x:Bind Title}"
                            IsTextSelectionEnabled="True"
+                           Text="{x:Bind Title}"
                            Style="{ThemeResource BaseTextBlockStyle}"
-                           Margin="6,6,0,0" />
+                           Margin="6,12,0,0" />
 
 
-                <TextBlock RelativePanel.RightOf="titoloEvento" x:Name="tipoEvento" TextWrapping="Wrap"
+                <TextBlock RelativePanel.RightOf="dataEnd" x:Name="tipoEvento" TextWrapping="Wrap"
+                           RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            MaxWidth="500"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                            Text="{x:Bind EventType}"
+                           FontWeight="Medium"
                            Style="{ThemeResource BaseTextBlockStyle}"
-                           Margin="6,6,0,0" />
+                           Margin="10,10,0,0" />
 
                 <!-- date of the lesson -->
                 <TextBlock RelativePanel.RightOf="tipoEvento" x:Name="date"
                            Text="{x:Bind CurrentObject.evtDatetimeBegin, Converter={StaticResource DateTimeToNormalDateConverter}}"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           Foreground="Transparent"
                            IsTextSelectionEnabled="True"
                            Margin="12,6,0,0" />
 
+                <TextBlock RelativePanel.RightOf="titoloEvento" RelativePanel.AlignVerticalCenterWith="titoloEvento"
+                           x:Name="dataStart"
 
-                <TextBlock RelativePanel.Below="titoloEvento" x:Name="dataStart"
-                           RelativePanel.RightOf="IconCalendar"
                            Text="{x:Bind  CurrentObject.evtDatetimeBegin, Converter={StaticResource DateTimeToHourConverter}}"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           IsTextSelectionEnabled="True"
-                           Margin="6,0,0,0" />
-
-                <TextBlock RelativePanel.RightOf="dataStart" RelativePanel.Below="titoloEvento"
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Margin="12,12,0,0" />
+                <!-- trattino -->
+                <TextBlock RelativePanel.RightOf="dataStart" RelativePanel.AlignVerticalCenterWith="titoloEvento"
                            x:Name="placeholderData"
                            Text="-"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           Margin="6,0,6,0" />
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Margin="6,12,6,0" />
 
-
-                <TextBlock RelativePanel.RightOf="placeholderData" RelativePanel.Below="titoloEvento" x:Name="dataEnd"
+                <TextBlock RelativePanel.RightOf="placeholderData" RelativePanel.AlignVerticalCenterWith="titoloEvento"
+                           x:Name="dataEnd"
                            Text="{x:Bind  CurrentObject.evtDatetimeEnd, Converter={StaticResource DateTimeToHourConverter}}"
-                           FontStyle="Italic"
+                           FontWeight="Medium"
                            Style="{ThemeResource BodyTextBlockStyle}"
-                           IsTextSelectionEnabled="True"
-                           Margin="0,0,0,0" />
+                           Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                           Margin="0,12,0,0" />
 
-                <TextBlock RelativePanel.Below="dataStart" x:Name="descriptionEvent"
+                <TextBlock RelativePanel.Below="titoloEvento" x:Name="descriptionEvent"
                            RelativePanel.RightOf="IconCalendar"
                            TextWrapping="Wrap"
                            Text="{x:Bind  CurrentObject.notes}"
                            Style="{ThemeResource BodyTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           FontWeight="SemiBold"
                            IsTextSelectionEnabled="True"
-                           Margin="6,6,0,6" />
+                           Margin="6,4,0,12" />
 
 
             </RelativePanel>

--- a/ClassevivaPCTO/Controls/GradesListView.xaml
+++ b/ClassevivaPCTO/Controls/GradesListView.xaml
@@ -34,7 +34,7 @@
                         <!-- ="{ThemeResource SystemControlBackgroundBaseMediumBrush}" -->
                     </Ellipse>
                     <TextBlock VerticalAlignment="Center" HorizontalAlignment="Center"
-                               Text="{x:Bind CurrentObject.displayValue}" FontSize="16" Foreground="#FFFFFF" />
+                               Text="{x:Bind CurrentObject.displayValue}" FontSize="16" Foreground="#FFFFFF" FontWeight="Medium"/>
 
                 </Grid>
 

--- a/ClassevivaPCTO/Controls/GradesListView.xaml
+++ b/ClassevivaPCTO/Controls/GradesListView.xaml
@@ -44,7 +44,7 @@
                                IsTextSelectionEnabled="True"
                                Text="{x:Bind CurrentObject.subjectDesc}"
                                Style="{ThemeResource BaseTextBlockStyle}"
-                               Margin="12,6,0,0" />
+                               Margin="12,10,0,2" />
 
                     <TextBlock RelativePanel.Below="textMateria"
                                TextWrapping="Wrap"
@@ -54,19 +54,19 @@
                                Style="{ThemeResource BodyTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                FontWeight="SemiBold"
-                               Margin="12,0,0,6" />
+                               Margin="12,0,0,10" />
 
                     <TextBlock RelativePanel.RightOf="textMateria" x:Name="dataVoto"
                                Text="{x:Bind CurrentObject.evtDate, Converter={StaticResource DateTimeToNormalDateConverter}}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="12,6,0,0"
+                               Margin="12,10,0,0"
                                IsTextSelectionEnabled="True"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontWeight="SemiBold" />
 
                     <TextBlock RelativePanel.RightOf="dataVoto"
                                Text="{x:Bind CurrentObject.componentDesc}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="12,6,0,0"
+                               Margin="12,10,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontWeight="SemiBold" />
 
                 </RelativePanel>

--- a/ClassevivaPCTO/Controls/GradesListView.xaml
+++ b/ClassevivaPCTO/Controls/GradesListView.xaml
@@ -38,13 +38,15 @@
 
                 </Grid>
 
-                <RelativePanel RelativePanel.AlignVerticalCenterWithPanel="True" RelativePanel.RightOf="gridVoto">
+                <RelativePanel RelativePanel.AlignVerticalCenterWithPanel="True" RelativePanel.RightOf="gridVoto"
+                               Margin="0,8,0,8">
+
                     <TextBlock x:Name="textMateria" TextWrapping="Wrap"
                                MaxWidth="500"
                                IsTextSelectionEnabled="True"
                                Text="{x:Bind CurrentObject.subjectDesc}"
                                Style="{ThemeResource BaseTextBlockStyle}"
-                               Margin="12,10,0,2" />
+                               Margin="12,0,0,2" />
 
                     <TextBlock RelativePanel.Below="textMateria"
                                TextWrapping="Wrap"
@@ -54,19 +56,19 @@
                                Style="{ThemeResource BodyTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                FontWeight="SemiBold"
-                               Margin="12,0,0,10" />
+                               Margin="12,0,0,0" />
 
                     <TextBlock RelativePanel.RightOf="textMateria" x:Name="dataVoto"
                                Text="{x:Bind CurrentObject.evtDate, Converter={StaticResource DateTimeToNormalDateConverter}}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="12,10,0,0"
+                               Margin="12,0,0,0"
                                IsTextSelectionEnabled="True"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontWeight="SemiBold" />
 
                     <TextBlock RelativePanel.RightOf="dataVoto"
                                Text="{x:Bind CurrentObject.componentDesc}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="12,10,0,0"
+                               Margin="12,0,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}" FontWeight="SemiBold" />
 
                 </RelativePanel>

--- a/ClassevivaPCTO/Controls/LessonsListView.xaml
+++ b/ClassevivaPCTO/Controls/LessonsListView.xaml
@@ -92,14 +92,16 @@
                     <TextBlock x:Name="textMateria" TextWrapping="WrapWholeWords"
                                MaxWidth="500"
                                Text="{x:Bind CurrentObject.subjectDesc}"
-                               Style="{ThemeResource BaseTextBlockStyle}"
                                IsTextSelectionEnabled="True"
+                               Style="{ThemeResource BaseTextBlockStyle}"
                                Margin="12,6,0,0" />
 
                     <TextBlock x:Name="durationHours" TextWrapping="NoWrap" RelativePanel.RightOf="textMateria"
                                MaxWidth="500"
                                Style="{ThemeResource BaseTextBlockStyle}"
-                               Margin="12,6,0,0">
+                               FontWeight="SemiBold"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                               Margin="10,6,0,0">
                         <Run Text="(" /><Run Text="{x:Bind Durata}" /><Run Text=")" />
                     </TextBlock>
 
@@ -107,15 +109,17 @@
                     <TextBlock RelativePanel.RightOf="durationHours" x:Name="date"
                                Text="{x:Bind CurrentObject.evtDate, Converter={StaticResource DateTimeToNormalDateConverter}}"
                                Style="{ThemeResource BodyTextBlockStyle}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               FontWeight="SemiBold"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                IsTextSelectionEnabled="True"
                                Margin="12,6,0,0" />
 
                     <TextBlock RelativePanel.Below="textMateria" x:Name="nomeAutore"
                                Text="{x:Bind CurrentObject.authorName}"
-                               FontStyle="Italic"
-                               Style="{ThemeResource BodyTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                               FontStyle="Italic" FontWeight="Medium"
                                IsTextSelectionEnabled="True"
+                               Style="{ThemeResource BodyTextBlockStyle}"
                                Margin="12,0,0,0" />
 
                     <TextBlock RelativePanel.Below="nomeAutore" x:Name="tipoLezione"
@@ -123,13 +127,14 @@
                                Style="{ThemeResource BodyTextBlockStyle}"
                                FontStyle="Italic"
                                Foreground="{x:Bind ColorBrush}"
-                               IsTextSelectionEnabled="True"
                                Margin="12,0,0,0" />
 
                     <TextBlock RelativePanel.Below="nomeAutore" RelativePanel.RightOf="tipoLezione"
                                TextWrapping="WrapWholeWords"
                                Text="{x:Bind CurrentObject.lessonArg}"
                                Style="{ThemeResource BodyTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               FontWeight="SemiBold"
                                IsTextSelectionEnabled="True"
                                Margin="12,0,0,6" />
 

--- a/ClassevivaPCTO/Controls/NoticesListView.xaml
+++ b/ClassevivaPCTO/Controls/NoticesListView.xaml
@@ -45,14 +45,14 @@
                     <FontIcon x:Name="pinIcon" FontFamily="{StaticResource FluentIcons}" Glyph="&#xE840;"
                               RelativePanel.AlignVerticalCenterWithPanel="True"
                               Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                              Margin="8,0,8,0" />
+                              Margin="8,0,10,0" />
 
                     <TextBlock x:Name="titoloEvento" TextWrapping="WrapWholeWords"
                                RelativePanel.RightOf="pinIcon"
                                IsTextSelectionEnabled="True"
                                Text="{x:Bind CurrentObject.cntTitle}"
                                Style="{ThemeResource BaseTextBlockStyle}"
-                               Margin="6,0,0,0" />
+                               Margin="6,2,0,0" />
 
                     <TextBlock x:Name="categoriaEvento" TextWrapping="NoWrap"
                                RelativePanel.RightOf="titoloEvento"
@@ -62,7 +62,7 @@
                                FontWeight="SemiBold"
                                Style="{ThemeResource BaseTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                               Margin="8,0,0,0" />
+                               Margin="8,2,4,0" />
 
 
                     <!-- data pubblicazione -->
@@ -72,7 +72,7 @@
                                Text="{x:Bind  CurrentObject.pubDT, Converter={StaticResource DateTimeToNormalDateConverter}}"
                                Style="{ThemeResource BodyStrongTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                               Margin="4,0,0,0" />
+                               Margin="0,2,0,0" />
 
 
                     <TextBlock x:Name="StatusText" RelativePanel.RightOf="dataPubblicazione" TextWrapping="NoWrap"
@@ -83,7 +83,7 @@
                                FontWeight="Medium"
                                Foreground="{x:Bind StatusTextColor}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="10,0,0,0" />
+                               Margin="8,0,0,0" />
 
 
                     <TextBlock x:Name="FromToDateText" RelativePanel.Below="titoloEvento" TextWrapping="Wrap"
@@ -93,7 +93,7 @@
                                FontWeight="Medium"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="6,6,0,0" />
+                               Margin="4,6,0,2" />
 
 
                 </RelativePanel>

--- a/ClassevivaPCTO/Controls/NoticesListView.xaml
+++ b/ClassevivaPCTO/Controls/NoticesListView.xaml
@@ -5,6 +5,7 @@
     xmlns:local="using:ClassevivaPCTO.Controls"
     xmlns:adapters="using:ClassevivaPCTO.Adapters"
     xmlns:converters="using:ClassevivaPCTO.Converters"
+    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
@@ -119,7 +120,7 @@
                         Visibility="{x:Bind IsDeleted, Converter={StaticResource BetterBoolToVisibilityConverter}, ConverterParameter=False}"
                         Click="ReadButton_Click"
                         Style="{ThemeResource TextButtonStyle}"
-                        Margin="0,0,8,0">
+                        Margin="0,0,8,0" toolkit:FrameworkElementExtensions.Cursor="Hand">
                         <Button.Content>
                             <StackPanel Orientation="Horizontal">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE890;" />

--- a/ClassevivaPCTO/Controls/NoticesListView.xaml
+++ b/ClassevivaPCTO/Controls/NoticesListView.xaml
@@ -40,7 +40,7 @@
 
 
                 <RelativePanel ScrollViewer.HorizontalScrollMode="Disabled" Grid.Row="0" Grid.Column="0"
-                               Margin="0,6,0,6">
+                               Margin="0,8,0,8">
 
                     <!-- icon pin -->
                     <FontIcon x:Name="pinIcon" FontFamily="{StaticResource FluentIcons}" Glyph="&#xE840;"
@@ -53,7 +53,7 @@
                                IsTextSelectionEnabled="True"
                                Text="{x:Bind CurrentObject.cntTitle}"
                                Style="{ThemeResource BaseTextBlockStyle}"
-                               Margin="6,2,0,0" />
+                               Margin="6,0,0,0" />
 
                     <TextBlock x:Name="categoriaEvento" TextWrapping="NoWrap"
                                RelativePanel.RightOf="titoloEvento"
@@ -63,7 +63,7 @@
                                FontWeight="SemiBold"
                                Style="{ThemeResource BaseTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                               Margin="8,2,4,0" />
+                               Margin="8,0,4,0" />
 
 
                     <!-- data pubblicazione -->
@@ -73,7 +73,7 @@
                                Text="{x:Bind  CurrentObject.pubDT, Converter={StaticResource DateTimeToNormalDateConverter}}"
                                Style="{ThemeResource BodyStrongTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                               Margin="0,2,0,0" />
+                               Margin="0,0,0,0" />
 
 
                     <TextBlock x:Name="StatusText" RelativePanel.RightOf="dataPubblicazione" TextWrapping="NoWrap"
@@ -94,7 +94,7 @@
                                FontWeight="Medium"
                                Foreground="{ThemeResource TextFillColorTertiaryBrush}"
                                Style="{ThemeResource CaptionTextBlockStyle}"
-                               Margin="4,6,0,2" />
+                               Margin="4,6,0,0" />
 
 
                 </RelativePanel>

--- a/ClassevivaPCTO/Controls/ScrutiniListView.xaml
+++ b/ClassevivaPCTO/Controls/ScrutiniListView.xaml
@@ -31,7 +31,7 @@
 
             <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"></RowDefinition>
+                    <RowDefinition MinHeight="60"></RowDefinition>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -79,7 +79,7 @@
                         Click="ButtonOpen_Click"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,14,0" Width="70">
+                        Margin="0,0,14,0" MinWidth="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0" VerticalAlignment="Center">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE8E5;"
@@ -94,7 +94,7 @@
                         RelativePanel.AlignRightWithPanel="True"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0" Width="70">
+                        Margin="0,0,12,0" MinWidth="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE74E;"
@@ -118,7 +118,7 @@
 
             <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"></RowDefinition>
+                    <RowDefinition MinHeight="60"></RowDefinition>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -156,7 +156,7 @@
                         x:Name="ButtonOpenReport"
                         Click="ButtonOpenReport_OnClick"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0" Width="70">
+                        Margin="0,0,12,0" MinWidth="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE71B;"

--- a/ClassevivaPCTO/Controls/ScrutiniListView.xaml
+++ b/ClassevivaPCTO/Controls/ScrutiniListView.xaml
@@ -79,11 +79,11 @@
                         Click="ButtonOpen_Click"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,14,0">
+                        Margin="0,0,14,0" Width="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0" VerticalAlignment="Center">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE8E5;"
-                                          FontSize="16" />
+                                          FontSize="16"/>
                                 <TextBlock FontSize="12" x:Uid="ButtonOpen" Margin="0,0,0,0" />
                             </StackPanel>
                         </Button.Content>
@@ -94,7 +94,7 @@
                         RelativePanel.AlignRightWithPanel="True"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0">
+                        Margin="0,0,12,0" Width="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE74E;"
@@ -111,6 +111,7 @@
         </DataTemplate>
 
 
+        
         <DataTemplate x:Key="SchoolReportListViewDataTemplate"
                       x:DataType="adapters:SchoolReportAdapter">
 
@@ -123,6 +124,7 @@
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
+
 
 
                 <RelativePanel ScrollViewer.HorizontalScrollMode="Disabled" Grid.Row="0" Grid.Column="0">
@@ -154,7 +156,7 @@
                         x:Name="ButtonOpenReport"
                         Click="ButtonOpenReport_OnClick"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0">
+                        Margin="0,0,12,0" Width="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE71B;"

--- a/ClassevivaPCTO/Controls/ScrutiniListView.xaml
+++ b/ClassevivaPCTO/Controls/ScrutiniListView.xaml
@@ -80,7 +80,7 @@
                         Click="ButtonOpen_Click"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,14,0" MinWidth="80">
+                        Margin="0,0,14,0" MinWidth="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0" VerticalAlignment="Center">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE8E5;"
@@ -95,7 +95,7 @@
                         RelativePanel.AlignRightWithPanel="True"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0" MinWidth="80">
+                        Margin="0,0,12,0" MinWidth="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE74E;"
@@ -157,7 +157,7 @@
                         x:Name="ButtonOpenReport"
                         Click="ButtonOpenReport_OnClick"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0" MinWidth="80">
+                        Margin="0,0,12,0" MinWidth="70">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE71B;"

--- a/ClassevivaPCTO/Controls/ScrutiniListView.xaml
+++ b/ClassevivaPCTO/Controls/ScrutiniListView.xaml
@@ -6,6 +6,7 @@
     xmlns:adapters="using:ClassevivaPCTO.Adapters"
     xmlns:converters="using:ClassevivaPCTO.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:microconverters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d"
@@ -79,7 +80,7 @@
                         Click="ButtonOpen_Click"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,14,0" MinWidth="70">
+                        Margin="0,0,14,0" MinWidth="80">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0" VerticalAlignment="Center">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE8E5;"
@@ -94,7 +95,7 @@
                         RelativePanel.AlignRightWithPanel="True"
                         Visibility="{x:Bind CurrentObject.checkStatus.available, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0" MinWidth="70">
+                        Margin="0,0,12,0" MinWidth="80">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE74E;"
@@ -152,15 +153,15 @@
                     Grid.Column="1"
                     Padding="0,6,0,6">
 
-                    <Button
+                    <Button toolkit:FrameworkElementExtensions.Cursor="Hand"
                         x:Name="ButtonOpenReport"
                         Click="ButtonOpenReport_OnClick"
                         RelativePanel.AlignVerticalCenterWithPanel="True"
-                        Margin="0,0,12,0" MinWidth="70">
+                        Margin="0,0,12,0" MinWidth="80">
                         <Button.Content>
                             <StackPanel Orientation="Vertical" Padding="6,0,6,0">
                                 <FontIcon FontFamily="{StaticResource FluentIcons}" Glyph="&#xE71B;"
-                                          FontSize="16" />
+                                          FontSize="16" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"/>
                                 <TextBlock FontSize="12" x:Uid="ButtonOpen" Margin="0,0,0,0" />
                             </StackPanel>
                         </Button.Content>

--- a/ClassevivaPCTO/Converters/GradeToColorConverter.cs
+++ b/ClassevivaPCTO/Converters/GradeToColorConverter.cs
@@ -22,7 +22,7 @@ namespace ClassevivaPCTO.Converters
 
             if (valore == null)
             {
-                brush.Color = Colors.DarkSlateBlue;
+                brush.Color = CurrentPalette.ColorBlue;
             }
             else if (valore >= 6)
             {

--- a/ClassevivaPCTO/Dialogs/FirstRunDialog.xaml
+++ b/ClassevivaPCTO/Dialogs/FirstRunDialog.xaml
@@ -1,5 +1,4 @@
 ﻿<ContentDialog
-
     x:Class="ClassevivaPCTO.Dialogs.FirstRunDialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -23,9 +22,10 @@
             </StackPanel>
         </DataTemplate>
     </ContentDialog.TitleTemplate>
-    <ScrollViewer>
+
+    <ScrollViewer MaxWidth="800">
         <StackPanel>
-            <TextBlock x:Uid="FirstRun_Body" TextWrapping="WrapWholeWords" MaxWidth="800"/>
+            <TextBlock x:Uid="FirstRun_Body" TextWrapping="WrapWholeWords"/>
         </StackPanel>
     </ScrollViewer>
 </ContentDialog>

--- a/ClassevivaPCTO/Dialogs/FirstRunDialog.xaml
+++ b/ClassevivaPCTO/Dialogs/FirstRunDialog.xaml
@@ -18,14 +18,14 @@
                     Source="ms-appx:///Assets/StoreLogo.png" />
                 <TextBlock
                     Margin="16"
-                    VerticalAlignment="Center"
+                    VerticalAlignment="Center" 
                     Text="{x:Bind}" />
             </StackPanel>
         </DataTemplate>
     </ContentDialog.TitleTemplate>
     <ScrollViewer>
         <StackPanel>
-            <TextBlock x:Uid="FirstRun_Body" TextWrapping="WrapWholeWords" />
+            <TextBlock x:Uid="FirstRun_Body" TextWrapping="WrapWholeWords" MaxWidth="800"/>
         </StackPanel>
     </ScrollViewer>
 </ContentDialog>

--- a/ClassevivaPCTO/Helpers/Palettes/IPalette.cs
+++ b/ClassevivaPCTO/Helpers/Palettes/IPalette.cs
@@ -23,9 +23,9 @@ namespace ClassevivaPCTO.Helpers.Palettes
         PALETTE_JAP,
         [ClassMapping(typeof(PaletteNat))]
         PALETTE_NAT,
-        [ClassMapping(typeof(PaletteNat))]
+        [ClassMapping(typeof(Palette4))]
         PALETTE_4,
-        [ClassMapping(typeof(PaletteNat))]
+        [ClassMapping(typeof(Palette5))]
         PALETTE_5,
 
     }

--- a/ClassevivaPCTO/Helpers/Palettes/IPalette.cs
+++ b/ClassevivaPCTO/Helpers/Palettes/IPalette.cs
@@ -9,9 +9,9 @@ namespace ClassevivaPCTO.Helpers.Palettes
     {
         Color ColorRed { get; }
         Color ColorOrange { get; }
-        Color ColorYellow { get; }
         Color ColorGreen { get; }
         Color ColorBlue { get; }
+        Color ColorYellow { get; }
 
     }
 
@@ -22,7 +22,12 @@ namespace ClassevivaPCTO.Helpers.Palettes
         [ClassMapping(typeof(PaletteJap))]
         PALETTE_JAP,
         [ClassMapping(typeof(PaletteNat))]
-        PALETTE_NAT
+        PALETTE_NAT,
+        [ClassMapping(typeof(PaletteNat))]
+        PALETTE_4,
+        [ClassMapping(typeof(PaletteNat))]
+        PALETTE_5,
+
     }
 
     [AttributeUsage(AttributeTargets.Field)]

--- a/ClassevivaPCTO/Helpers/Palettes/Palettes.cs
+++ b/ClassevivaPCTO/Helpers/Palettes/Palettes.cs
@@ -10,9 +10,9 @@ namespace ClassevivaPCTO.Helpers.Palettes
         {
             public Color ColorRed => ColorHelper.ToColor("#CF5955");
             public Color ColorOrange => ColorHelper.ToColor("#EE9B4C");
-            public Color ColorYellow => ColorHelper.ToColor("#EE9B4C");
             public Color ColorGreen => ColorHelper.ToColor("#7EAE83");
             public Color ColorBlue => ColorHelper.ToColor("#5E97B2");
+            public Color ColorYellow => Colors.Goldenrod;
 
         }
 
@@ -20,9 +20,9 @@ namespace ClassevivaPCTO.Helpers.Palettes
         {
             public Color ColorRed => Colors.Crimson;
             public Color ColorOrange => Colors.DarkOrange;
-            public Color ColorYellow => Colors.Goldenrod;
             public Color ColorGreen => Colors.Teal;
-            public Color ColorBlue => ColorHelper.ToColor("#483D8B");
+            public Color ColorBlue => Colors.DarkSlateBlue;
+            public Color ColorYellow => Colors.Goldenrod;
 
         }
 
@@ -30,9 +30,29 @@ namespace ClassevivaPCTO.Helpers.Palettes
         {
             public Color ColorRed => ColorHelper.ToColor("#9A4D31");
             public Color ColorOrange => ColorHelper.ToColor("#FC9553");
-            public Color ColorYellow => ColorHelper.ToColor("#FC9553");
             public Color ColorGreen => ColorHelper.ToColor("#78C141");
             public Color ColorBlue => ColorHelper.ToColor("#42AACD");
+            public Color ColorYellow => Colors.Goldenrod;
+        }
+
+        public class Palette4 : IPalette
+        {
+            public Color ColorRed => ColorHelper.ToColor("#9A4D31");
+            public Color ColorOrange => ColorHelper.ToColor("#FC9553");
+            public Color ColorGreen => ColorHelper.ToColor("#78C141");
+            public Color ColorBlue => ColorHelper.ToColor("#42AACD");
+            public Color ColorYellow => Colors.Goldenrod;
+
+        }
+      
+        public class Palette5 : IPalette
+        {
+            public Color ColorRed => ColorHelper.ToColor("#9A4D31");
+            public Color ColorOrange => ColorHelper.ToColor("#FC9553");
+            public Color ColorGreen => ColorHelper.ToColor("#78C141");
+            public Color ColorBlue => ColorHelper.ToColor("#42AACD");
+            public Color ColorYellow => Colors.Goldenrod;
+
         }
     }
 }

--- a/ClassevivaPCTO/Helpers/Palettes/Palettes.cs
+++ b/ClassevivaPCTO/Helpers/Palettes/Palettes.cs
@@ -28,7 +28,7 @@ namespace ClassevivaPCTO.Helpers.Palettes
 
         public class PaletteNat : IPalette
         {
-            public Color ColorRed => ColorHelper.ToColor("#9A4D31");
+            public Color ColorRed => ColorHelper.ToColor("#A25E50");
             public Color ColorOrange => ColorHelper.ToColor("#FC9553");
             public Color ColorGreen => ColorHelper.ToColor("#78C141");
             public Color ColorBlue => ColorHelper.ToColor("#42AACD");
@@ -37,10 +37,10 @@ namespace ClassevivaPCTO.Helpers.Palettes
 
         public class Palette4 : IPalette
         {
-            public Color ColorRed => ColorHelper.ToColor("#9A4D31");
-            public Color ColorOrange => ColorHelper.ToColor("#FC9553");
-            public Color ColorGreen => ColorHelper.ToColor("#78C141");
-            public Color ColorBlue => ColorHelper.ToColor("#42AACD");
+            public Color ColorRed => ColorHelper.ToColor("#FF0000");
+            public Color ColorOrange => ColorHelper.ToColor("#FF7D00");
+            public Color ColorGreen => ColorHelper.ToColor("#00FF00");
+            public Color ColorBlue => ColorHelper.ToColor("#0000FF");
             public Color ColorYellow => Colors.Goldenrod;
 
         }

--- a/ClassevivaPCTO/Strings/it-it/Resources.resw
+++ b/ClassevivaPCTO/Strings/it-it/Resources.resw
@@ -453,4 +453,13 @@ Gli account studente hanno l'username che inizia con le lettere S, G o X.</value
   <data name="SettingsChangeProfilePicButton.Text" xml:space="preserve">
     <value>Cambia foto</value>
   </data>
+  <data name="Settings_Language_De_DE.Content" xml:space="preserve">
+    <value>Tedesco</value>
+  </data>
+  <data name="Settings_Language_Es_ES.Content" xml:space="preserve">
+    <value>Spagnolo</value>
+  </data>
+  <data name="Settings_Language_Fr_FR.Content" xml:space="preserve">
+    <value>Francese</value>
+  </data>
 </root>

--- a/ClassevivaPCTO/Strings/it-it/Resources.resw
+++ b/ClassevivaPCTO/Strings/it-it/Resources.resw
@@ -428,7 +428,7 @@ Gli account studente hanno l'username che inizia con le lettere S, G o X.</value
     <value>Traduci su Crowdin</value>
   </data>
   <data name="PALETTE_CV" xml:space="preserve">
-    <value>Predefinito di Classeviva</value>
+    <value>Classeviva</value>
   </data>
   <data name="PALETTE_JAP" xml:space="preserve">
     <value>Semaforo giapponese</value>

--- a/ClassevivaPCTO/Views/Agenda.xaml
+++ b/ClassevivaPCTO/Views/Agenda.xaml
@@ -262,7 +262,7 @@
                                             FirstDayOfWeek="Monday"
                                             toolkit:FrameworkElementExtensions.Cursor="Hand"
                                             PlaceholderText="Scegli una data" Grid.Row="1" Margin="8,0,8,0"
-                                            RelativePanel.AlignVerticalCenterWithPanel="True" />
+                                            RelativePanel.AlignVerticalCenterWithPanel="True"/>
 
                         <Button x:Name="ButtonTomorrow" Margin="0,0,0,0"
                                 RelativePanel.LeftOf="ButtonToday"

--- a/ClassevivaPCTO/Views/Agenda.xaml
+++ b/ClassevivaPCTO/Views/Agenda.xaml
@@ -86,7 +86,7 @@
                 <RelativePanel
                     Grid.Row="0"
                     Margin="0,0,0,24">
-                    <TextBlock x:Name="TitoloLezioniPopup" x:Uid="LessonsTitle" FontSize="42"
+                    <TextBlock x:Name="TitoloLezioniPopup" x:Uid="LessonsTitle" Style="{StaticResource TitleLargeTextBlockStyle}"
                                VerticalAlignment="Top"
                                Margin="32,16,0,0" />
 
@@ -96,7 +96,7 @@
                         IsActive="True"
                         RelativePanel.RightOf="TitoloLezioniPopup"
                         RelativePanel.AlignVerticalCenterWith="TitoloLezioniPopup"
-                        Margin="32,16,0,0" />
+                        Margin="16,16,0,0" Width="28" Height="28" />
 
 
                 </RelativePanel>
@@ -147,7 +147,7 @@
                 <RelativePanel
                     Grid.Row="0"
                     Margin="0,0,0,24">
-                    <TextBlock x:Name="TitoloAgendaPopup" x:Uid="TitoloAgendaPopup" FontSize="42"
+                    <TextBlock x:Name="TitoloAgendaPopup" x:Uid="TitoloAgendaPopup" Style="{StaticResource TitleLargeTextBlockStyle}"
                                VerticalAlignment="Top"
                                Margin="32,16,0,0" />
 
@@ -158,7 +158,7 @@
                         IsActive="True"
                         RelativePanel.RightOf="TitoloAgendaPopup"
                         RelativePanel.AlignVerticalCenterWith="TitoloAgendaPopup"
-                        Margin="32,16,0,0" />
+                        Margin="16,16,0,0" Width="28" Height="28" />
                 </RelativePanel>
 
 
@@ -260,6 +260,7 @@
                         <CalendarDatePicker x:Name="CalendarAgenda"
                                             RelativePanel.LeftOf="ButtonTomorrow"
                                             FirstDayOfWeek="Monday"
+                                            toolkit:FrameworkElementExtensions.Cursor="Hand"
                                             PlaceholderText="Scegli una data" Grid.Row="1" Margin="8,0,8,0"
                                             RelativePanel.AlignVerticalCenterWithPanel="True" />
 

--- a/ClassevivaPCTO/Views/Agenda.xaml
+++ b/ClassevivaPCTO/Views/Agenda.xaml
@@ -249,6 +249,7 @@
                                 RelativePanel.LeftOf="CalendarAgenda"
                                 Width="48"
                                 Height="32"
+                                toolkit:FrameworkElementExtensions.Cursor="Hand"
                                 Click="ButtonYesterday_Click" ToolTipService.ToolTip="Giorno precedente">
                             <FontIcon FontSize="16" Glyph="&#xE76B;" HorizontalAlignment="Center"
                                       VerticalAlignment="Center" />
@@ -267,6 +268,7 @@
                                 Width="48"
                                 Height="32"
                                 RelativePanel.AlignVerticalCenterWithPanel="True"
+                                toolkit:FrameworkElementExtensions.Cursor="Hand"
                                 Click="ButtonTomorrow_Click" ToolTipService.ToolTip="Giorno successivo">
                             <FontIcon FontSize="16" Glyph="&#xE76C;" HorizontalAlignment="Center"
                                       VerticalAlignment="Center" />

--- a/ClassevivaPCTO/Views/Agenda.xaml
+++ b/ClassevivaPCTO/Views/Agenda.xaml
@@ -86,7 +86,7 @@
                 <RelativePanel
                     Grid.Row="0"
                     Margin="0,0,0,24">
-                    <TextBlock x:Name="TitoloLezioniPopup" x:Uid="LessonsTitle" Style="{StaticResource TitleLargeTextBlockStyle}"
+                    <TextBlock x:Name="TitoloLezioniPopup" x:Uid="LessonsTitle" FontSize="42"
                                VerticalAlignment="Top"
                                Margin="32,16,0,0" />
 
@@ -147,7 +147,7 @@
                 <RelativePanel
                     Grid.Row="0"
                     Margin="0,0,0,24">
-                    <TextBlock x:Name="TitoloAgendaPopup" x:Uid="TitoloAgendaPopup" Style="{StaticResource TitleLargeTextBlockStyle}"
+                    <TextBlock x:Name="TitoloAgendaPopup" x:Uid="TitoloAgendaPopup" FontSize="42"
                                VerticalAlignment="Top"
                                Margin="32,16,0,0" />
 

--- a/ClassevivaPCTO/Views/Agenda.xaml.cs
+++ b/ClassevivaPCTO/Views/Agenda.xaml.cs
@@ -61,12 +61,12 @@ namespace ClassevivaPCTO.Views
                 //if the date is today, then the button to go to today is disabled
                 if (agendaSelectedDate.Value.Date == DateTime.Now.Date)
                 {
-                    ButtonToday.IsChecked = true;
+                    ButtonToday.IsChecked = false;
                     //ButtonToday.IsEnabled = false;
                 }
                 else
                 {
-                    ButtonToday.IsChecked = false;
+                    ButtonToday.IsChecked = true;
                     //ButtonToday.IsEnabled = true;
                 }
 

--- a/ClassevivaPCTO/Views/Assenze.xaml
+++ b/ClassevivaPCTO/Views/Assenze.xaml
@@ -110,7 +110,7 @@
 
 
                 <RelativePanel
-                    Margin="18,0,16,0"
+                    Margin="18,0,8,20"
                     Grid.Column="0"
                     VerticalAlignment="Stretch" HorizontalAlignment="Stretch"
                     x:Name="CardPanel"
@@ -122,9 +122,8 @@
 
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     Background="{ThemeResource CardBackgroundFillColorDefaultBrush}">
-
-
-                    <Grid
+                      
+                        <Grid
                         x:Name="Grid1"
                         HorizontalAlignment="Stretch"
 

--- a/ClassevivaPCTO/Views/DashboardPage.xaml
+++ b/ClassevivaPCTO/Views/DashboardPage.xaml
@@ -162,7 +162,7 @@
 
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <TextBlock Text="Apri Agenda" />
-                            <FontIcon FontSize="12" Margin="0,4,0,0" Glyph="&#xE76C;" VerticalAlignment="Center" />
+                            <FontIcon FontSize="12" Glyph="&#xE76C;" VerticalAlignment="Center" />
 
 
                         </StackPanel>
@@ -241,7 +241,7 @@
 
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <TextBlock Text="Visualizza tutte le valutazioni" />
-                            <FontIcon FontSize="12" Margin="0,4,0,0" Glyph="&#xE76C;" VerticalAlignment="Center" />
+                            <FontIcon FontSize="12" Glyph="&#xE76C;" VerticalAlignment="Center" />
 
 
                         </StackPanel>
@@ -305,7 +305,7 @@
 
                         <StackPanel Orientation="Horizontal" Spacing="4">
                             <TextBlock Text="Apri Bacheca" />
-                            <FontIcon FontSize="12" Margin="0,4,0,0" Glyph="&#xE76C;" VerticalAlignment="Center" />
+                            <FontIcon FontSize="12" Glyph="&#xE76C;" VerticalAlignment="Center" />
 
 
                         </StackPanel>

--- a/ClassevivaPCTO/Views/DashboardPage.xaml.cs
+++ b/ClassevivaPCTO/Views/DashboardPage.xaml.cs
@@ -104,7 +104,7 @@ namespace ClassevivaPCTO.Views
                 .GetGrades(cardResult.usrId.ToString())
                 .ConfigureAwait(false);
 
-            var fiveMostRecent = result1.Grades.OrderByDescending(x => x.evtDate).Take(5);
+            var fiveMostRecent = result1.Grades.OrderByDescending(x => x.evtDate).Take(4);
 
             //update UI on UI thread
             await CoreApplication.MainView.Dispatcher.RunAsync(
@@ -168,7 +168,7 @@ namespace ClassevivaPCTO.Views
             var fiveMostRecent = resultNotices.Notices
                 .Where(x => x.cntValidInRange)
                 .OrderByDescending(x => x.cntValidFrom)
-                .Take(5);
+                .Take(4);
 
             //update UI on UI thread
             await CoreApplication.MainView.Dispatcher.RunAsync(

--- a/ClassevivaPCTO/Views/DettaglioVoti.xaml
+++ b/ClassevivaPCTO/Views/DettaglioVoti.xaml
@@ -2,15 +2,11 @@
     x:Class="ClassevivaPCTO.Views.DettaglioVoti"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:ClassevivaPCTO"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     xmlns:controls2="using:ClassevivaPCTO.Controls"
-    xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     muxc:BackdropMaterial.ApplyToRootOrPageBackground="True">
 

--- a/ClassevivaPCTO/Views/DettaglioVoti.xaml
+++ b/ClassevivaPCTO/Views/DettaglioVoti.xaml
@@ -8,6 +8,7 @@
     mc:Ignorable="d"
     xmlns:controls2="using:ClassevivaPCTO.Controls"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+    xmlns:labs="using:CommunityToolkit.Labs.WinUI"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"

--- a/ClassevivaPCTO/Views/DettaglioVoti.xaml.cs
+++ b/ClassevivaPCTO/Views/DettaglioVoti.xaml.cs
@@ -75,6 +75,7 @@ namespace ClassevivaPCTO.Views
             AggiornaListViewVoti();
         }
 
+
         private void AggiornaComboMaterie()
         {
             //pulisco il ComboMaterie

--- a/ClassevivaPCTO/Views/DettaglioVoti.xaml.cs
+++ b/ClassevivaPCTO/Views/DettaglioVoti.xaml.cs
@@ -9,6 +9,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
+
 namespace ClassevivaPCTO.Views
 {
     public sealed partial class DettaglioVoti : Page
@@ -168,3 +169,4 @@ namespace ClassevivaPCTO.Views
         }
     }
 }
+

--- a/ClassevivaPCTO/Views/SettingsPage.xaml
+++ b/ClassevivaPCTO/Views/SettingsPage.xaml
@@ -224,7 +224,7 @@
 
                                         <Border Width="24"
                                                 Height="24"
-                                                Background="{x:Bind CurrentPalette.ColorYellow, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                                                Background="{x:Bind CurrentPalette.ColorBlue, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
                                                 CornerRadius="26"
                                                 IsTapEnabled="False" ToolTipService.ToolTip="Non fa media, uscita" />
 

--- a/ClassevivaPCTO/Views/SettingsPage.xaml
+++ b/ClassevivaPCTO/Views/SettingsPage.xaml
@@ -10,6 +10,7 @@
     xmlns:palette="using:ClassevivaPCTO.Helpers.Palettes"
     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:adapters="using:ClassevivaPCTO.Adapters"
+    xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI"
     xmlns:converters="using:ClassevivaPCTO.Converters"
     mc:Ignorable="d">
     <Page.Resources>
@@ -256,6 +257,33 @@
                            x:Uid="Settings_General" />
 
 
+                <labs:SettingsCard Header="Vai all'anno precedente">
+                    
+
+                    <labs:SettingsCard.HeaderIcon>
+                        <FontIcon Glyph="&#xE97A;" />
+                    </labs:SettingsCard.HeaderIcon>
+
+                    <labs:SettingsCard.Description>
+                        <TextBlock Text="Consulta i dati dell'A.S. 2022/23 sul sito web di Classeviva" />
+                    </labs:SettingsCard.Description>
+
+                    <Button MinWidth="130" toolkit:FrameworkElementExtensions.Cursor="Hand">
+
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8">
+
+                            <TextBlock Text="A.S. 2022/23" />
+
+                            <TextBlock Text="&#xE8A7;" VerticalAlignment="Center"
+                                       FontFamily="{StaticResource FluentIcons}" Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"/>
+
+                        </StackPanel>
+
+
+                    </Button>
+
+                </labs:SettingsCard>
+
                 <labs:SettingsCard x:Uid="SettingsCardLanguage">
 
                     <labs:SettingsCard.HeaderIcon>
@@ -273,6 +301,22 @@
                             x:Uid="Settings_Language_En_US">
 
                         </ComboBoxItem>
+
+                        <ComboBoxItem
+                            x:Uid="Settings_Language_Es_ES">
+
+                        </ComboBoxItem>
+
+                        <ComboBoxItem
+                            x:Uid="Settings_Language_Fr_FR">
+
+                        </ComboBoxItem>
+
+                        <ComboBoxItem
+                            x:Uid="Settings_Language_De_DE">
+
+                        </ComboBoxItem>
+
 
                     </ComboBox>
 

--- a/ClassevivaPCTO/Views/SettingsPage.xaml
+++ b/ClassevivaPCTO/Views/SettingsPage.xaml
@@ -186,7 +186,7 @@
 
                 <labs:SettingsCard x:Name="ColorSchemeExpander"
                                    Description="Personalizza lo schema dei colori utilizzato nell'app per indicare voti ed eventi"
-                                   Header="Schema colori" MinHeight="80" MaxHeight="80">
+                                   Header="Schema colori" MinHeight="80">
 
                     <labs:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE790;" />

--- a/ClassevivaPCTO/Views/SettingsPage.xaml
+++ b/ClassevivaPCTO/Views/SettingsPage.xaml
@@ -101,7 +101,7 @@
                                        FontSize="14"
                                        FontWeight="Medium"
                                        Margin="0,10,0,0" Foreground="{ThemeResource TextFillColorTertiaryBrush}">
-                                <Run Text="Codice studente: " /><Run Text="{Binding Codice}" />
+                                <Run Text="Codice studente: " /><Run Text="{Binding Codice}"/>
                             </TextBlock>
 
                             <TextBlock x:Name="Scuola"
@@ -185,7 +185,7 @@
 
                 <labs:SettingsCard x:Name="ColorSchemeExpander"
                                    Description="Personalizza lo schema dei colori utilizzato nell'app per indicare voti ed eventi"
-                                   Header="Schema colori">
+                                   Header="Schema colori" MinHeight="80" MaxHeight="80">
 
                     <labs:SettingsCard.HeaderIcon>
                         <FontIcon Glyph="&#xE790;" />
@@ -199,8 +199,23 @@
                             <DataTemplate x:DataType="adapters:ComboPaletteAdapter">
                                 <StackPanel Orientation="Horizontal">
 
+                                    
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8"
                                                 Margin="0,4,0,0">
+
+                                   <!-- <TextBlock Text="{x:Bind PaletteNameTranslatedResource}" Margin="0,0,0,0" /> -->
+
+                                        <Border Width="24"
+                                                Height="24"
+                                                Background="{x:Bind CurrentPalette.ColorRed, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                                                CornerRadius="26"
+                                                IsTapEnabled="False" ToolTipService.ToolTip="Insufficienza grave, assenza" />
+
+                                        <Border Width="24"
+                                                Height="24"
+                                                Background="{x:Bind CurrentPalette.ColorOrange, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
+                                                CornerRadius="26"
+                                                IsTapEnabled="False" ToolTipService.ToolTip="Insufficienza lieve, ritardo" />
 
                                         <Border Width="24"
                                                 Height="24"
@@ -210,24 +225,9 @@
 
                                         <Border Width="24"
                                                 Height="24"
-                                                Background="{x:Bind CurrentPalette.ColorOrange, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
-                                                CornerRadius="26"
-                                                IsTapEnabled="False"
-                                                ToolTipService.ToolTip="Insufficienza lieve, ritardo" />
-
-                                        <Border Width="24"
-                                                Height="24"
-                                                Background="{x:Bind CurrentPalette.ColorRed, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
-                                                CornerRadius="26"
-                                                IsTapEnabled="False"
-                                                ToolTipService.ToolTip="Insufficienza grave, assenza" />
-
-                                        <Border Width="24"
-                                                Height="24"
                                                 Background="{x:Bind CurrentPalette.ColorBlue, Converter={StaticResource ColorToBrushConverter}, Mode=OneWay}"
                                                 CornerRadius="26"
                                                 IsTapEnabled="False" ToolTipService.ToolTip="Non fa media, uscita" />
-
 
                                     </StackPanel>
 
@@ -297,7 +297,7 @@
                         <FontIcon Glyph="&#xEA80;" />
                     </labs:SettingsCard.HeaderIcon>
 
-                    <Button x:Uid="SettingsCardTutorialButton" MinWidth="130" />
+                    <Button x:Uid="SettingsCardTutorialButton" MinWidth="130" Click="ButtonTutorial_OnClick" />
 
                 </labs:SettingsCard>
 

--- a/ClassevivaPCTO/Views/SettingsPage.xaml.cs
+++ b/ClassevivaPCTO/Views/SettingsPage.xaml.cs
@@ -163,6 +163,12 @@ namespace ClassevivaPCTO.Views
             await dialog.ShowAsync();
         }
 
+        private async void ButtonTutorial_OnClick(object sender, RoutedEventArgs e)
+        {
+            var dialog = new FirstRunDialog();
+            await dialog.ShowAsync();
+        }
+
         private async void ThemeSelector_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             ComboBox themeSelector = (ComboBox) sender;


### PR DESCRIPTION
- closed #67 
- aggiornate alcune listview per migliorare gli spazi e rendere più pulita l'interfaccia
- temporaneamente limitato a 4 il numero di elementi da caricare nei widget voti e bacheca per evitare che si sovrappongrano agli hyperlink, quando faremo la nuova dashboard torneranno come prima
- aggiunte due nuove palette (placeholder, verranno implementate in futuro)
- migliorata la disposizione dei colori nelle palette (adesso è rosso - arancione - verde - blu)
- fixato il colore dei voti che non fanno media nella GradesListView
- fixata la SettingsCard delle palette in modo che non si ridimensioni automaticamente
- experiemtal: aggiunto dialog tutorial
- fixati i margini dei documenti non disponibili in scrutinio tramite il MinHeight

-------------------[2e59dcd]
- aggiunto placeholder #71
- aggiunti placeholder e strings lingua tedesca, spagnolo e francese
- corrette le listview AgendaPopup e LezioniPopup + titoli e progressring
- altri miglioramenti alle listview