### PR TITLE
Fix design inconsinstencies between dialogs

### DIFF
--- a/ClassevivaPCTO/Dialogs/FirstRunDialog.xaml
+++ b/ClassevivaPCTO/Dialogs/FirstRunDialog.xaml
@@ -6,7 +6,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="345"
     d:DesignWidth="550"
-    mc:Ignorable="d">
+    mc:Ignorable="d"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    PrimaryButtonStyle="{StaticResource DefaultButtonStyle}" >
 
     <ContentDialog.TitleTemplate>
         <DataTemplate x:DataType="x:String">

--- a/ClassevivaPCTO/Dialogs/WhatsNewDialog.xaml
+++ b/ClassevivaPCTO/Dialogs/WhatsNewDialog.xaml
@@ -6,7 +6,9 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     d:DesignHeight="500"
     d:DesignWidth="750"
-    mc:Ignorable="d" Opacity="1">
+    mc:Ignorable="d"
+    Style="{StaticResource DefaultContentDialogStyle}"
+    PrimaryButtonStyle="{StaticResource DefaultButtonStyle}" >
 
     <ContentDialog.TitleTemplate>
         <DataTemplate x:DataType="x:String">


### PR DESCRIPTION
i dialog what's new e get started sono stati aggiornati per matchare gli altri dialog dell'app

PRIMA
![image](https://github.com/Gabboxl/ClassevivaPCTO/assets/90320229/dae188ae-12d4-40a2-844b-d89c8c531780)

DOPO
![image](https://github.com/Gabboxl/ClassevivaPCTO/assets/90320229/8efcec9d-98bb-4b5b-b85a-80cbb6c8bdce)
